### PR TITLE
Add links to information about proposals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@taquito/taquito": "^19.1.0",
         "antd": "^5.16.0",
         "clsx": "^2.1.0",
+        "fast-deep-equal": "^3.1.3",
         "next": "14.1.0",
         "patch-package": "^8.0.0",
         "react": "^18.2.0",
@@ -2660,7 +2661,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@taquito/taquito": "^19.1.0",
     "antd": "^5.16.0",
     "clsx": "^2.1.0",
+    "fast-deep-equal": "^3.1.3",
     "next": "14.1.0",
     "patch-package": "^8.0.0",
     "react": "^18.2.0",

--- a/public/external_link.svg
+++ b/public/external_link.svg
@@ -1,0 +1,1 @@
+<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="rgb(89 173 140)" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>

--- a/src/app/components/voting/common/index.ts
+++ b/src/app/components/voting/common/index.ts
@@ -1,1 +1,2 @@
 export * from './payloadKey';
+export * from './informationLink';

--- a/src/app/components/voting/common/informationLink/index.ts
+++ b/src/app/components/voting/common/informationLink/index.ts
@@ -1,0 +1,1 @@
+export * from './informationLink';

--- a/src/app/components/voting/common/informationLink/informationLink.module.css
+++ b/src/app/components/voting/common/informationLink/informationLink.module.css
@@ -1,0 +1,17 @@
+a.externalLink::after
+{
+  content: "";
+  width: 11px;
+  height: 11px;
+  margin-left: 4px;
+  background-image: url("/external_link.svg");
+  color: rgb(89 173 140);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  display: inline-block;
+}
+
+a.externalLink {
+  color: rgb(89 173 140);
+}

--- a/src/app/components/voting/common/informationLink/informationLink.tsx
+++ b/src/app/components/voting/common/informationLink/informationLink.tsx
@@ -3,6 +3,7 @@ import styles from "./informationLink.module.css";
 
 // Data about proposals and links to information about them
 import { allLinkData } from "@/data/proposals";
+import equal from 'fast-deep-equal';
 
 interface InformationLinkProps {
   payloadKey: PayloadKey,
@@ -11,7 +12,7 @@ interface InformationLinkProps {
 export const InformationLink: React.FC<InformationLinkProps> = ({
   payloadKey
 }) => {
-  const linkData = allLinkData.find((d) => JSON.stringify(d.payloadKey) === JSON.stringify(payloadKey));
+  const linkData = allLinkData.find((d) => equal(d.payloadKey, payloadKey));
   
   if (!linkData) {
     return null;

--- a/src/app/components/voting/common/informationLink/informationLink.tsx
+++ b/src/app/components/voting/common/informationLink/informationLink.tsx
@@ -1,27 +1,25 @@
+import { PayloadKey } from '@/lib/governance';
 import styles from "./informationLink.module.css";
 
 // Data about proposals and links to information about them
 import { allLinkData } from "@/data/proposals";
 
 interface InformationLinkProps {
-  cycle: number,
+  payloadKey: PayloadKey,
 }
 
-export const InformationLink = ({ cycle }: InformationLinkProps) => {
-
-  // Get currently selected governance contract via parsing the URL.
-  // There is probably a better way to do this but I couldn't find the type of governance from the contract.
-  const currentUrl = window.location.href;
-  const currentPeriodType = currentUrl.split('/').find((subPath) => ['kernel', 'security'].includes(subPath));
-
-  const linkData = allLinkData.find(({ cycles, periodType }) => cycles.includes(cycle) && periodType === currentPeriodType);
-
+export const InformationLink: React.FC<InformationLinkProps> = ({
+  payloadKey
+}) => {
+  const linkData = allLinkData.find((d) => JSON.stringify(d.payloadKey) === JSON.stringify(payloadKey));
+  
   if (!linkData) {
-    return <></>;
+    return null;
   }
 
   return <div>
-    <a className={styles.externalLink} href={linkData.href} target="_blank">{linkData.title}
+    <a className={styles.externalLink} href={linkData.href} target="_blank">
+      {linkData.title}
     </a>
   </div>
 }

--- a/src/app/components/voting/common/informationLink/informationLink.tsx
+++ b/src/app/components/voting/common/informationLink/informationLink.tsx
@@ -1,24 +1,11 @@
 import styles from "./informationLink.module.css";
 
+// Data about proposals and links to information about them
+import { allLinkData } from "@/data/proposals";
+
 interface InformationLinkProps {
   cycle: number,
 }
-
-// Data about proposals and links to information about them
-const allLinkData = [
-  {
-    periodType: 'kernel',
-    cycles: [134, 135],
-    href: 'https://medium.com/@etherlink/announcing-calypso-the-next-etherlink-upgrade-proposal-dbe92c576da9',
-    title: 'Announcing Calypso: The Next Etherlink Upgrade Proposal',
-  },
-  {
-    periodType: 'kernel',
-    cycles: [83],
-    href: 'https://medium.com/etherlink/announcing-bifr%C3%B6st-a-2nd-upgrade-proposal-for-etherlink-mainnet-ef1a7cf9715f',
-    title: 'Announcing Bifröst: a 2nd upgrade proposal for Etherlink Mainnet',
-  },
-];
 
 export const InformationLink = ({ cycle }: InformationLinkProps) => {
 

--- a/src/app/components/voting/common/informationLink/informationLink.tsx
+++ b/src/app/components/voting/common/informationLink/informationLink.tsx
@@ -1,0 +1,40 @@
+import styles from "./informationLink.module.css";
+
+interface InformationLinkProps {
+  cycle: number,
+}
+
+// Data about proposals and links to information about them
+const allLinkData = [
+  {
+    periodType: 'kernel',
+    cycles: [134, 135],
+    href: 'https://medium.com/@etherlink/announcing-calypso-the-next-etherlink-upgrade-proposal-dbe92c576da9',
+    title: 'Announcing Calypso: The Next Etherlink Upgrade Proposal',
+  },
+  {
+    periodType: 'kernel',
+    cycles: [83],
+    href: 'https://medium.com/etherlink/announcing-bifr%C3%B6st-a-2nd-upgrade-proposal-for-etherlink-mainnet-ef1a7cf9715f',
+    title: 'Announcing Bifröst: a 2nd upgrade proposal for Etherlink Mainnet',
+  },
+];
+
+export const InformationLink = ({ cycle }: InformationLinkProps) => {
+
+  // Get currently selected governance contract via parsing the URL.
+  // There is probably a better way to do this but I couldn't find the type of governance from the contract.
+  const currentUrl = window.location.href;
+  const currentPeriodType = currentUrl.split('/').find((subPath) => ['kernel', 'security'].includes(subPath));
+
+  const linkData = allLinkData.find(({ cycles, periodType }) => cycles.includes(cycle) && periodType === currentPeriodType);
+
+  if (!linkData) {
+    return <></>;
+  }
+
+  return <div>
+    <a className={styles.externalLink} href={linkData.href} target="_blank">{linkData.title}
+    </a>
+  </div>
+}

--- a/src/app/components/voting/promotionState/promotionState.tsx
+++ b/src/app/components/voting/promotionState/promotionState.tsx
@@ -24,7 +24,7 @@ export const PromotionState = ({ contractAddress, promotionPeriod, config }: Pro
       {promotionPeriod.winnerCandidate && <div className="flex flex-col">
         <span>Candidate:</span>
         <PayloadKey value={promotionPeriod.winnerCandidate} />
-        <InformationLink cycle={promotionPeriod.index} />
+        <InformationLink payloadKey={promotionPeriod.winnerCandidate} />
       </div>}
 
       <div className="flex flex-col gap-4">

--- a/src/app/components/voting/promotionState/promotionState.tsx
+++ b/src/app/components/voting/promotionState/promotionState.tsx
@@ -2,7 +2,7 @@ import { PromotionPeriod } from '@/lib/governance/state';
 import { getPromotionQuorumPercent, getPromotionSupermajorityPercent, natToPercent } from '@/lib/governance/utils';
 import { GovernanceConfig } from '@/lib/governance/config';
 import { TotalVoteCard, TotalVoteType } from './totalVoteCard';
-import { ProgressPure, GlobalMessagePure, PayloadKey } from '@/app/components';
+import { ProgressPure, GlobalMessagePure, PayloadKey, InformationLink } from '@/app/components';
 import { VotersTable } from './votersTable';
 
 interface PromotionStateProps {
@@ -24,6 +24,7 @@ export const PromotionState = ({ contractAddress, promotionPeriod, config }: Pro
       {promotionPeriod.winnerCandidate && <div className="flex flex-col">
         <span>Candidate:</span>
         <PayloadKey value={promotionPeriod.winnerCandidate} />
+        <InformationLink cycle={promotionPeriod.index} />
       </div>}
 
       <div className="flex flex-col gap-4">

--- a/src/app/components/voting/proposalState/proposalState.tsx
+++ b/src/app/components/voting/proposalState/proposalState.tsx
@@ -25,7 +25,7 @@ export const ProposalState = ({ contractAddress, proposalPeriod, config }: Propo
       <h2 className="text-xl">Proposals</h2>
       <ProgressPure text="Quorum" value={proposalQuorum} target={minimumProposalQuorum} />
     </div>
-    <ProposalList proposals={proposalPeriod.proposals} winnerCandidate={proposalPeriod.winnerCandidate} periodIndex={proposalPeriod.index} />
+    <ProposalList proposals={proposalPeriod.proposals} winnerCandidate={proposalPeriod.winnerCandidate} />
 
     <h2 className="text-xl mb-2">Upvoters</h2>
     <UpvotersTable

--- a/src/app/components/voting/proposalState/proposalState.tsx
+++ b/src/app/components/voting/proposalState/proposalState.tsx
@@ -25,7 +25,7 @@ export const ProposalState = ({ contractAddress, proposalPeriod, config }: Propo
       <h2 className="text-xl">Proposals</h2>
       <ProgressPure text="Quorum" value={proposalQuorum} target={minimumProposalQuorum} />
     </div>
-    <ProposalList proposals={proposalPeriod.proposals} winnerCandidate={proposalPeriod.winnerCandidate} />
+    <ProposalList proposals={proposalPeriod.proposals} winnerCandidate={proposalPeriod.winnerCandidate} periodIndex={proposalPeriod.index} />
 
     <h2 className="text-xl mb-2">Upvoters</h2>
     <UpvotersTable

--- a/src/app/components/voting/proposalState/proposalsList.tsx
+++ b/src/app/components/voting/proposalState/proposalsList.tsx
@@ -39,7 +39,7 @@ export const ProposalList = ({ proposals, winnerCandidate, periodIndex }: Propos
             <span className={`break-all ${appTheme.disabledTextColor}`}>
               (by <LinkPure className="underline" href={context.explorer.getAccountUrl(p.proposer)} target="_blank">{p.proposer}</LinkPure>)
             </span>
-            <InformationLink cycle={periodIndex} />
+            <InformationLink payloadKey={p.key} />
           </div>
           <div className="flex flex-row sm:flex-col gap-1">
             <span>Upvotes:</span>

--- a/src/app/components/voting/proposalState/proposalsList.tsx
+++ b/src/app/components/voting/proposalState/proposalsList.tsx
@@ -1,16 +1,17 @@
 'use client'
 
 import clsx from 'clsx'
-import { appTheme, LinkPure, IntValuePure, useClientContext, PayloadKey } from '@/app/components'
+import { appTheme, LinkPure, IntValuePure, useClientContext, PayloadKey, InformationLink } from '@/app/components'
 import { Proposal, PayloadKey as PayloadKeyType } from '@/lib/governance'
 import { useState } from 'react'
 
 interface ProposalListProps {
   proposals: Proposal[];
+  periodIndex: number;
   winnerCandidate: NonNullable<PayloadKeyType> | null;
 }
 
-export const ProposalList = ({ proposals, winnerCandidate }: ProposalListProps) => {
+export const ProposalList = ({ proposals, winnerCandidate, periodIndex }: ProposalListProps) => {
   const [showAll, setShowAll] = useState(false);
   const handleShowAllClick = () => {
     setShowAll((v) => !v);
@@ -38,6 +39,7 @@ export const ProposalList = ({ proposals, winnerCandidate }: ProposalListProps) 
             <span className={`break-all ${appTheme.disabledTextColor}`}>
               (by <LinkPure className="underline" href={context.explorer.getAccountUrl(p.proposer)} target="_blank">{p.proposer}</LinkPure>)
             </span>
+            <InformationLink cycle={periodIndex} />
           </div>
           <div className="flex flex-row sm:flex-col gap-1">
             <span>Upvotes:</span>

--- a/src/app/components/voting/proposalState/proposalsList.tsx
+++ b/src/app/components/voting/proposalState/proposalsList.tsx
@@ -7,11 +7,10 @@ import { useState } from 'react'
 
 interface ProposalListProps {
   proposals: Proposal[];
-  periodIndex: number;
   winnerCandidate: NonNullable<PayloadKeyType> | null;
 }
 
-export const ProposalList = ({ proposals, winnerCandidate, periodIndex }: ProposalListProps) => {
+export const ProposalList = ({ proposals, winnerCandidate }: ProposalListProps) => {
   const [showAll, setShowAll] = useState(false);
   const handleShowAllClick = () => {
     setShowAll((v) => !v);

--- a/src/data/proposals.ts
+++ b/src/data/proposals.ts
@@ -1,0 +1,16 @@
+// Info with links to web pages about proposals
+
+export const allLinkData = [
+  {
+    periodType: 'kernel',
+    cycles: [134, 135],
+    href: 'https://medium.com/@etherlink/announcing-calypso-the-next-etherlink-upgrade-proposal-dbe92c576da9',
+    title: 'Announcing Calypso: The Next Etherlink Upgrade Proposal',
+  },
+  {
+    periodType: 'kernel',
+    cycles: [83],
+    href: 'https://medium.com/etherlink/announcing-bifr%C3%B6st-a-2nd-upgrade-proposal-for-etherlink-mainnet-ef1a7cf9715f',
+    title: 'Announcing Bifröst: a 2nd upgrade proposal for Etherlink Mainnet',
+  },
+];

--- a/src/data/proposals.ts
+++ b/src/data/proposals.ts
@@ -1,15 +1,21 @@
 // Info with links to web pages about proposals
 
-export const allLinkData = [
+import { PayloadKey } from '@/lib/governance';
+
+interface LinkData {
+  payloadKey: PayloadKey;
+  href: string;
+  title: string;
+}
+
+export const allLinkData: LinkData[] = [
   {
-    periodType: 'kernel',
-    cycles: [134, 135],
+    payloadKey: '00224058a50dbf4c0b5f6d5e4ee672cd63d0911959b335e587b4112a7eea7b2323',
     href: 'https://medium.com/@etherlink/announcing-calypso-the-next-etherlink-upgrade-proposal-dbe92c576da9',
     title: 'Announcing Calypso: The Next Etherlink Upgrade Proposal',
   },
   {
-    periodType: 'kernel',
-    cycles: [83],
+    payloadKey: '00fda6968ec17ed11dee02dc91d15606e6f02c8d7e00d8baeaee24fc0188898261',
     href: 'https://medium.com/etherlink/announcing-bifr%C3%B6st-a-2nd-upgrade-proposal-for-etherlink-mainnet-ef1a7cf9715f',
     title: 'Announcing Bifröst: a 2nd upgrade proposal for Etherlink Mainnet',
   },


### PR DESCRIPTION
We'd like to provide links for people to get info about proposed updates. This PR adds a table of info about updates and shows a link when you load info about that cycle and proposal period type:

<img width="757" alt="Screenshot 2025-02-26 at 2 19 49 PM" src="https://github.com/user-attachments/assets/89af74e8-3dbe-4c3d-8405-62c2aca1a800" />
