### PR TITLE
Support several contract versions in config

### DIFF
--- a/src/app/[contract]/period/[[...periodIndex]]/page.tsx
+++ b/src/app/[contract]/period/[[...periodIndex]]/page.tsx
@@ -24,17 +24,14 @@ export const generateMetadata = ({ params }: HomeProps): Metadata => {
 
 export default async function Home({ params }: HomeProps) {
   const context = getAppContext();
-  const contract = context.config.contracts.find(c => c.name === params.contract);
-  if (!contract)
-    return redirectToPeriodPage(context.config.contracts[0].name);
+  const currentBlockLevel = await context.blockchain.getCurrentBlockLevel();
+  const contracts = context.getContracts(currentBlockLevel);
+  const contract = contracts.find(c => c.name === params.contract);
 
-  const [
-    currentBlockLevel,
-    config
-  ] = await Promise.all([
-    context.blockchain.getCurrentBlockLevel(),
-    context.governance.config.getConfig(contract.address)
-  ]);
+  if (!contract)
+    return redirectToPeriodPage(contracts[0].name);
+
+  const config = await context.governance.config.getConfig(contract.address);
 
   const { startedAtLevel, periodLength } = config;
   const currentPeriodIndex = getCurrentPeriodIndex(currentBlockLevel, startedAtLevel, periodLength);

--- a/src/app/actions/preload.ts
+++ b/src/app/actions/preload.ts
@@ -2,5 +2,6 @@ import { getAppContext } from '@/lib/appContext'
 
 export const preload = (): void => {
   const context = getAppContext();
-  context.config.contracts.forEach(c => context.governance.config.getConfig(c.address));
-} 
+  Object.values(context.config.contracts)
+    .forEach(arr => arr.forEach(c => context.governance.config.getConfig(c.address)));
+}

--- a/src/app/components/layout/navLinks.tsx
+++ b/src/app/components/layout/navLinks.tsx
@@ -2,11 +2,13 @@ import { LinkPure } from '@/app/components';
 import { getAppContext } from '@/lib/appContext';
 import { getPeriodPageUrl } from '@/app/actions';
 
-export const NavLinks = () => {
+export const NavLinks = async () => {
   const context = getAppContext();
-
+  const currentBlockLevel = await context.blockchain.getCurrentBlockLevel();
+  const contracts = context.getContracts(currentBlockLevel);
+  
   return <div className="flex flex-row flex-wrap gap-x-4 gap-y-2 justify-center items-center">
-    {context.config.contracts.map((contract) => {
+    {contracts.map((contract) => {
       return (
         <LinkPure
           key={contract.name}

--- a/src/lib/appContext/appContext.ts
+++ b/src/lib/appContext/appContext.ts
@@ -1,10 +1,10 @@
 import { BlockchainProvider } from '../blockchain';
-import { Config } from '../config';
-import { Explorer } from '../explorer';
+import { Config, Contract } from '../config';
 import { GovernanceConfigProvider, GovernanceStateProvider, GovernancePeriodsProvider, GovernanceOperationsProvider } from '../governance';
 
 export interface AppContext {
   config: Config;
+  getContracts: (currentBlockLevel: number) => Contract[]
   allConfigs: Config[];
   blockchain: BlockchainProvider;
   governance: {

--- a/src/lib/appContext/getAppContext.ts
+++ b/src/lib/appContext/getAppContext.ts
@@ -22,10 +22,21 @@ export const getAppContext = (): AppContext => {
 
     const toolkit = new TezosToolkit(config.rpcUrl);
     // const blockchainProvider = new TzktProvider(config.tzktApiUrl);
-    const blockchainProvider = new TempTzktProvider(config.tzktApiUrl,  config.rpcUrl);
+    const blockchainProvider = new TempTzktProvider(config.tzktApiUrl, config.rpcUrl);
 
     appContext = {
       config,
+      getContracts: (currentBlockLevel: number) => {
+        const contractKeys = Object.keys(config.contracts);
+        const contractLevel = contractKeys.reduce((maxLevel, levelStr) => {
+          const level = parseInt(levelStr, 10);
+          if (!isNaN(level) && level <= currentBlockLevel && (maxLevel === null || level > maxLevel)) {
+            return level;
+          }
+          return maxLevel;
+        }, null as number | null);
+        return contractLevel == null ? [] : config.contracts[contractLevel];
+      },
       allConfigs: allConfigs.map(c => buildConfig(c)).filter((c): c is Config => !!c),
       blockchain: blockchainProvider,
       governance: {

--- a/src/lib/config/networks/ghostnet.ts
+++ b/src/lib/config/networks/ghostnet.ts
@@ -11,30 +11,34 @@ export const ghostnetConfig: BaseConfig = {
   key: 'ghostnet',
   name: 'Ghostnet',
   ...ghostnetBase,
-  contracts: [{
-    address: 'KT1MtNbeDYiBTFHfKrocHdzds1GYKNkNeAfe',
-    name: 'kernel'
-  }, {
-    address: 'KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk',
-    name: 'security'
-  }, {
-    address: 'KT1LBBNtit9k2YU1eky2YqTFeqrpLqAhc1T8',
-    name: 'sequencer'
-  }]
+  contracts: {
+    0: [{
+      address: 'KT1MtNbeDYiBTFHfKrocHdzds1GYKNkNeAfe',
+      name: 'kernel'
+    }, {
+      address: 'KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk',
+      name: 'security'
+    }, {
+      address: 'KT1LBBNtit9k2YU1eky2YqTFeqrpLqAhc1T8',
+      name: 'sequencer'
+    }]
+  }
 };
 
 export const ghostnetTestConfig: BaseConfig = {
   key: 'ghostnet_demo',
   name: 'Demo',
   ...ghostnetBase,
-  contracts: [{
-    address: 'KT1QucBSp3oNuYXieNCw9ojpC3KTvccg4JMo',
-    name: 'kernel'
-  }, {
-    address: 'KT1MHAVKVVDSgZsKiwNrRfYpKHiTLLrtGqod',
-    name: 'security'
-  }, {
-    address: 'KT1V7eizWmUKSu8oFPaLTpCKsMh6QgD33m9i',
-    name: 'sequencer'
-  }]
+  contracts: {
+    0: [{
+      address: 'KT1QucBSp3oNuYXieNCw9ojpC3KTvccg4JMo',
+      name: 'kernel'
+    }, {
+      address: 'KT1MHAVKVVDSgZsKiwNrRfYpKHiTLLrtGqod',
+      name: 'security'
+    }, {
+      address: 'KT1V7eizWmUKSu8oFPaLTpCKsMh6QgD33m9i',
+      name: 'sequencer'
+    }]
+  }
 };

--- a/src/lib/config/networks/mainnet.ts
+++ b/src/lib/config/networks/mainnet.ts
@@ -7,14 +7,37 @@ export const mainnetConfig: BaseConfig = {
   rpcUrl: 'https://rpc.tzkt.io/mainnet',
   tzktApiUrl: 'https://api.tzkt.io',
   tzktExplorerUrl: 'https://tzkt.io',
-  contracts: [{
-    address: 'KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK',
-    name: 'kernel'
-  }, {
-    address: 'KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2',
-    name: 'security'
-  }, {
-    address: 'KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U',
-    name: 'sequencer'
-  }]
+  contracts: {
+    5316609: [
+      {
+        address: 'KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J',
+        name: 'kernel'
+      }, {
+        address: 'KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g',
+        name: 'security'
+      }, {
+        address: 'KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF',
+        name: 'sequencer'
+      }],
+    7692289: [{
+      address: 'KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK',
+      name: 'kernel'
+    }, {
+      address: 'KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2',
+      name: 'security'
+    }, {
+      address: 'KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U',
+      name: 'sequencer'
+    }],
+    8767489: [{
+      address: 'KT1XdSAYGXrUDE1U5GNqUKKscLWrMhzyjNeh',
+      name: 'kernel'
+    }, {
+      address: 'KT1D1fRgZVdjTj5sUZKcSTPPnuR7LRxVYnDL',
+      name: 'security'
+    }, {
+      address: 'KT1NnH9DCAoY1pfPNvb9cw9XPKQnHAFYFHXa',
+      name: 'sequencer'
+    }]
+  },
 };

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -12,7 +12,7 @@ export interface BaseConfig {
   key: string;
   name: string;
   network: Network;
-  contracts: Contract[];
+  contracts: Record<number, Contract[]>;
   rpcUrl: string;
   tzktApiUrl: string;
   tzktExplorerUrl: string;

--- a/src/lib/governance/state/providers/rpcProvider.ts
+++ b/src/lib/governance/state/providers/rpcProvider.ts
@@ -336,6 +336,6 @@ export class RpcGovernanceStateProvider implements GovernanceStateProvider {
       } as Proposal));
     }
 
-    return proposals.toSorted((a, b) => b.upvotesVotingPower > a.upvotesVotingPower ? 1 : b.upvotesVotingPower < a.upvotesVotingPower ? -1 : 0);
+    return proposals.sort((a, b) => b.upvotesVotingPower > a.upvotesVotingPower ? 1 : b.upvotesVotingPower < a.upvotesVotingPower ? -1 : 0);
   }
 }


### PR DESCRIPTION
Now, the config lists new, current, and even old contract versions.
The new contracts will take effect as soon as the current block level is greater than or equal to the startLevelAt specified for each contract in the [config](https://github.com/etherlinkcom/governance-website/blob/34d0f424ca0cbc1494bb7cc2dd56ccc5b1847945/src/lib/config/networks/mainnet.ts).