### PR TITLE
Rename kernel/security to slow/fast

### DIFF
--- a/src/app/views/homeView.tsx
+++ b/src/app/views/homeView.tsx
@@ -18,10 +18,10 @@ export const HomeView = () => {
     <hr className={`${appTheme.borderColor}`} />
     <h2 className="text-xl mt-8 mb-4">Etherlink governance</h2>
     <p className="mb-2">
-      Like Tezos, Etherlink has a built-in on-chain mechanism for proposing, selecting, testing, and activating upgrades without the need to hard fork. This mechanism makes Etherlink self-amending and empowers Tezos bakers to govern Etherlink’s kernel upgrades, security updates, and sequencer operators.
+      Like Tezos, Etherlink has a built-in on-chain mechanism for proposing, selecting, testing, and activating upgrades without the need to hard fork. This mechanism makes Etherlink self-amending and empowers Tezos bakers to govern Etherlink’s kernel upgrades and sequencer operators.
     </p>
     <p className="mb-8">
-      Etherlink has separate governance processes for <LinkPure className={linksClassName} href={getPeriodPageUrl('kernel')}>the kernel</LinkPure>, for <LinkPure className={linksClassName} href={getPeriodPageUrl('security')}>security incidents</LinkPure>, and for <LinkPure className={linksClassName} href={getPeriodPageUrl('sequencer')}>the Sequencer Committee</LinkPure>. To ensure that decisions accurately reflect the consensus of the Etherlink community, all three governance processes are designed with the same robust safeguards. Like Tezos&apos;s governance process, Etherlink&apos;s governance process promotes transparency and fairness in decision-making.
+      Etherlink has separate governance processes for <LinkPure className={linksClassName} href={getPeriodPageUrl('slow')}>slow kernel updates</LinkPure>, for <LinkPure className={linksClassName} href={getPeriodPageUrl('fast')}>fast kernel updates</LinkPure>, and for <LinkPure className={linksClassName} href={getPeriodPageUrl('sequencer')}>the Sequencer Committee</LinkPure>. To ensure that decisions accurately reflect the consensus of the Etherlink community, all three governance processes are designed with the same robust safeguards. Like Tezos&apos;s governance process, Etherlink&apos;s governance process promotes transparency and fairness in decision-making.
     </p>
     <hr className={`${appTheme.borderColor}`} />
     <h2 className="text-xl mt-8 mb-4">Learn more</h2>

--- a/src/lib/config/networks/ghostnet.ts
+++ b/src/lib/config/networks/ghostnet.ts
@@ -13,10 +13,10 @@ export const ghostnetConfig: BaseConfig = {
   ...ghostnetBase,
   contracts: [{
     address: 'KT1MtNbeDYiBTFHfKrocHdzds1GYKNkNeAfe',
-    name: 'kernel'
+    name: 'slow'
   }, {
     address: 'KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk',
-    name: 'security'
+    name: 'fast'
   }, {
     address: 'KT1LBBNtit9k2YU1eky2YqTFeqrpLqAhc1T8',
     name: 'sequencer'
@@ -29,10 +29,10 @@ export const ghostnetTestConfig: BaseConfig = {
   ...ghostnetBase,
   contracts: [{
     address: 'KT1QucBSp3oNuYXieNCw9ojpC3KTvccg4JMo',
-    name: 'kernel'
+    name: 'slow'
   }, {
     address: 'KT1MHAVKVVDSgZsKiwNrRfYpKHiTLLrtGqod',
-    name: 'security'
+    name: 'fast'
   }, {
     address: 'KT1V7eizWmUKSu8oFPaLTpCKsMh6QgD33m9i',
     name: 'sequencer'

--- a/src/lib/config/networks/mainnet.ts
+++ b/src/lib/config/networks/mainnet.ts
@@ -9,10 +9,10 @@ export const mainnetConfig: BaseConfig = {
   tzktExplorerUrl: 'https://tzkt.io',
   contracts: [{
     address: 'KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK',
-    name: 'kernel'
+    name: 'slow'
   }, {
     address: 'KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2',
-    name: 'security'
+    name: 'fast'
   }, {
     address: 'KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U',
     name: 'sequencer'


### PR DESCRIPTION
Per https://github.com/etherlinkcom/docs/pull/319, we are renaming kernel and security upgrades to slow and fast upgrades. This PR updates the terminology on the governance site to match.