### PR TITLE
Correct voting contracts for Dyonisus

### DIFF
--- a/src/lib/config/networks/mainnet.ts
+++ b/src/lib/config/networks/mainnet.ts
@@ -7,14 +7,15 @@ export const mainnetConfig: BaseConfig = {
   rpcUrl: 'https://rpc.tzkt.io/mainnet',
   tzktApiUrl: 'https://api.tzkt.io',
   tzktExplorerUrl: 'https://tzkt.io',
+  // All contracts below are for Dyonisus
   contracts: [{
-    address: 'KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK',
+    address: 'KT1XdSAYGXrUDE1U5GNqUKKscLWrMhzyjNeh',
     name: 'slow'
   }, {
-    address: 'KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2',
+    address: 'KT1D1fRgZVdjTj5sUZKcSTPPnuR7LRxVYnDL',
     name: 'fast'
   }, {
-    address: 'KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U',
+    address: 'KT1NnH9DCAoY1pfPNvb9cw9XPKQnHAFYFHXa',
     name: 'sequencer'
   }]
 };


### PR DESCRIPTION
The current voting contracts are for Calypso. This PR uses the voting contract for Dyonisus.  For reference we have:


### Slow kernel governance:
`KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK` (calypso)
`KT1XdSAYGXrUDE1U5GNqUKKscLWrMhzyjNeh` (dyonisus)
`KT1VZVNCNnhUp7s15d9RsdycP7C1iwYhAQ8r` ( To be released: Dyonisus 4.1)

### Fast kernel governance:
`KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2` (calypso)
`KT1D1fRgZVdjTj5sUZKcSTPPnuR7LRxVYnDL` (dyonisus)
`KT1DxndcFitAbxLdJCN3C1pPivqbC3RJxD1R` ( To be proposed in Dyonisus 4.1)

### Sequencer governance:
`KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U` (calypso)
`KT1NnH9DCAoY1pfPNvb9cw9XPKQnHAFYFHXa` (dyonisus)
`KT1WckZ2uiLfHCfQyNp1mtqeRcC1X6Jg2Qzf` (To be proposed in Dyonisus 4.1)
